### PR TITLE
feat: Add cmd+enter hotkey for post submission in Editor component

### DIFF
--- a/src/renderer/pages/Pile/Editor/index.jsx
+++ b/src/renderer/pages/Pile/Editor/index.jsx
@@ -107,6 +107,21 @@ export default function Editor({
     setEditable(false);
   }, [editor, isNew, post]);
 
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        handleSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    // Cleanup function to remove the event listener when the component unmounts
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleSubmit]); // Add handleSubmit to the dependency array
+
   const generateAiResponse = useCallback(async () => {
     if (!editor) return;
     if (isAIResponding) return;


### PR DESCRIPTION
This PR adds a new feature to the Editor component: a hotkey (Cmd+Enter or Ctrl+Enter) for post submission. 

- Added a `useEffect` hook in the Editor component to listen for the Cmd+Enter (or Ctrl+Enter) key combination.
- When the hotkey is detected, the `handleSubmit` function is triggered to submit the post.

- Manual testing was performed to ensure the hotkey triggers post submission as expected.

Please review and provide any feedback.
