### PR TITLE
<textarea> Resizing Issue Fix

### DIFF
--- a/src/renderer/pages/Pile/Settings/Settings.module.scss
+++ b/src/renderer/pages/Pile/Settings/Settings.module.scss
@@ -185,6 +185,8 @@ input {
     font-size: 14px;
     line-height: 1.35;
     min-height: 150px;
+    width: 100%; /* Ensure the width is 100%, no less, no more */
+    resize: none; /* Prevent resizing */
     color: var(--primary);
     background: var(--bg-tertiary);
     border: none;

--- a/src/renderer/pages/Pile/Settings/index.jsx
+++ b/src/renderer/pages/Pile/Settings/index.jsx
@@ -96,7 +96,7 @@ export default function Settings() {
             </label>
             <textarea
               className={styles.Textarea}
-              placeholder="Paste an OpenAI API key to enable AI reflections"
+              placeholder="Enter your own prompt for AI reflections"
               value={prompt}
               readOnly
             />


### PR DESCRIPTION
👋 Hi @UdaraJay and @khakimov!

This is a super small detail, but what are your thoughts on this?

### Before
<img width="460px" alt="Screenshot 2023-11-09 at 4 25 17 PM" src="https://github.com/UdaraJay/Pile/assets/46631279/cc4f4085-0aae-4ce1-8bf8-c78779b54807">

### After
<img width="330px" alt="Screenshot 2023-11-09 at 4 25 44 PM" src="https://github.com/UdaraJay/Pile/assets/46631279/621f921b-cca5-4936-a359-a9aae0ab0692">

### Details
Updated the textarea element within the settings page with **two changes**:
- The `<textarea>` now **cannot** be resized, and is always set to fill 100% of its container (`width: 100%`).
- The `placeholder="..."` is now `"Enter your own prompt for AI reflections"` instead of `"Paste an OpenAI API key to enable AI reflections"`. You can't see this because the `<textarea>` is currently readonly, but I assume this will change in the near future. (Feel free to change the this!)

**Side note:** In the future when users are able to edit their AI prompt, maybe deleting `resize: none;` and allowing the user to resize the `<textarea>` vertically would be a good idea.