### PR TITLE
Issue: 48 when you scroll down or explore through the entries, the in…

### DIFF
--- a/src/renderer/pages/Pile/Posts/Post/Ball/Ball.module.scss
+++ b/src/renderer/pages/Pile/Posts/Post/Ball/Ball.module.scss
@@ -6,7 +6,6 @@
     border-radius: 90px;
     user-select: none;
     position: relative;
-    z-index: 1;
     transition: all ease-in-out 120ms;
     margin: 4px 0;
 

--- a/src/renderer/pages/Pile/Posts/Post/Post.module.scss
+++ b/src/renderer/pages/Pile/Posts/Post/Post.module.scss
@@ -14,7 +14,7 @@
     display: flex;
     position: relative;
     padding: 0 18px;
-
+    margin-top: 2px;
     .left {
         display: flex;
         flex-direction: column;
@@ -34,7 +34,6 @@
             border-radius: 90px;
             user-select: none;
             position: relative;
-            z-index: 1;
             transition: all ease-in-out 120ms;
             margin: 4px 0;
 
@@ -138,7 +137,6 @@
 
             .time {
                 position: relative;
-                z-index: 1;
                 color: var(--secondary);
                 font-size: 0.9em;
                 padding: 3px 5px;

--- a/src/renderer/pages/Pile/Posts/VirtualList.jsx
+++ b/src/renderer/pages/Pile/Posts/VirtualList.jsx
@@ -67,6 +67,7 @@ const VirtualList = memo(({ data }) => {
         computeItemKey={getKey}
         atTopThreshold={300}
         overscan={500}
+        topItemCount={1}
         // style={{ height: windowHeight }}
         // increaseViewportBy={{ top: 5000, bottom: 5000 }}
         // useWindowScroll


### PR DESCRIPTION
…put clears

Issue: https://github.com/UdaraJay/Pile/issues/48


Modifications: Implemented the solution from https://virtuoso.dev/top-items to address the problem. This modification ensures that the 'edit post box' div remains fixed in place, maintaining its visibility even when scrolling. Furthermore, it was necessary to eliminate the z-index from both the 'ball' and 'time' elements within a post, as they were previously overlaying the pinned post box.

<img width="1077" alt="image" src="https://github.com/UdaraJay/Pile/assets/46779831/ebdb411f-a506-4bad-aca9-b7437a2e633f">

Also, added 2px margin-top to fix the layout issue.

<img width="1086" alt="image" src="https://github.com/UdaraJay/Pile/assets/46779831/85bb6c07-f825-4857-9941-bee33ea8bbfd">
