### PR TITLE
Close ai post reply on error

### DIFF
--- a/src/renderer/context/ToastsContext.js
+++ b/src/renderer/context/ToastsContext.js
@@ -3,7 +3,6 @@ import {
   createContext,
   useContext,
   useEffect,
-  useCallback,
   useRef,
 } from 'react';
 
@@ -18,7 +17,16 @@ export const ToastsContextProvider = ({ children }) => {
     if (notificationsQueue.length > 0) {
       // Set a timeout to dismiss the first notification
       notificationTimeoutRef.current = setTimeout(() => {
-        setNotificationsQueue((currentQueue) => currentQueue.slice(1));
+        setNotificationsQueue((currentQueue) => {
+          const rest = currentQueue.slice(1)
+
+          if (rest.length !== 0) {
+            const next = rest[0];
+            next.onEnter && next.onEnter();
+          }
+
+          return rest;
+        });
       }, notificationsQueue[0].dismissTime || 5000); // Default 5 seconds
     }
   };
@@ -45,9 +53,10 @@ export const ToastsContextProvider = ({ children }) => {
     type = 'info',
     message,
     dismissTime = 5000,
-    immediate = false
+    immediate = false,
+    onEnter = null,
   }) => {
-    const newNotification = { id, type, message, dismissTime };
+    const newNotification = { id, type, message, dismissTime, onEnter };
     setNotificationsQueue((currentQueue) => immediate ? [newNotification] : [...currentQueue, newNotification]);
   };
 

--- a/src/renderer/pages/Pile/Editor/index.jsx
+++ b/src/renderer/pages/Pile/Editor/index.jsx
@@ -250,7 +250,7 @@ const Editor = memo(
             max_tokens: 200,
             messages: context,
           });
-  
+
           for await (const part of stream) {
             const token = part.choices[0].delta.content;
             editor.commands.insertContent(token);
@@ -261,11 +261,12 @@ const Editor = memo(
             type: 'failed',
             message: 'AI request failed',
             dismissTime: 12000,
+            onEnter: closeReply
           });
           setIsAiResponding(false);
           return;
         }
-       
+
         removeNotification('reflecting');
         setIsAiResponding(false);
       }


### PR DESCRIPTION
When there's an error requesting the openai api, the user is left with a blank reply -- this PR fixes that by closing the reply when the notification is shown to the user. We technically know sooner when an error has occurred, but this makes for a cleaner UX. 