### PR TITLE
Show Ollama toggle

### DIFF
--- a/src/renderer/context/AIContext.js
+++ b/src/renderer/context/AIContext.js
@@ -50,7 +50,7 @@ export const AIContextProvider = ({ children }) => {
   const setupAi = useCallback(async () => {
     const key = await getKey();
 
-    if (!key) return;
+    if (!key && !getOllamaStatus()) return;
 
     const openaiInstance = new OpenAI({
       baseURL: baseUrl,

--- a/src/renderer/pages/Pile/Settings/index.jsx
+++ b/src/renderer/pages/Pile/Settings/index.jsx
@@ -54,7 +54,7 @@ export default function Settings() {
   };
 
   const handleSaveChanges = () => {
-    if (key == '') {
+    if (!key || key == '') {
       deleteKey();
     } else {
       setKey(key);
@@ -103,7 +103,7 @@ export default function Settings() {
           </fieldset>
 
           <div className={styles.providers}>
-            {/* <fieldset className={styles.switch}>
+            <fieldset className={styles.switch}>
               <label className={styles.Label} htmlFor="toggle-ollama">
                 <OllamaIcon className={styles.icon} /> Use Ollama API
               </label>
@@ -115,7 +115,7 @@ export default function Settings() {
                 />
                 <span className={styles.slider}></span>
               </label>
-            </fieldset> */}
+            </fieldset>
 
             <div className={styles.group}>
               <fieldset className={styles.Fieldset}>


### PR DESCRIPTION
Since https://github.com/ollama/ollama/issues/4388 has been resolved last month I uncommented the toggle for switching to Ollama. I also modified the `AIContext.js` so that the `openaiInstance` gets created despite no key being provided while using Ollama.

Lastly, I made a small change to `handleSaveChanges` in the Settings dialog, because `key` is `null` when I start Pile without an API key entered. Without this fix, clicking "Save changes" would crash the application for me with the error `Error: invoking remote method 'set-ai-key': Error: Password is required.`.

Once merged, #53 could be closed as well.