### PR TITLE
Disable AI buttons if AI API key is invalid

### DIFF
--- a/src/renderer/context/AIContext.js
+++ b/src/renderer/context/AIContext.js
@@ -123,6 +123,17 @@ export const AIContextProvider = ({ children }) => {
     [prompt]
   );
 
+  const checkApiKeyValidity = async () => {
+    // TODO: Add regex for OpenAPI and Ollama API keys
+    const key = await window.electron.ipc.invoke('get-ai-key');
+    
+    if (key !== null) {
+      return true;
+    }
+
+    return false;
+  }
+
   const AIContextValue = {
     ai,
     baseUrl,
@@ -131,6 +142,7 @@ export const AIContextProvider = ({ children }) => {
     setPrompt,
     setKey: (secretKey) => window.electron.ipc.invoke('set-ai-key', secretKey),
     getKey: () => window.electron.ipc.invoke('get-ai-key'),
+    validKey: checkApiKeyValidity,
     deleteKey: () => window.electron.ipc.invoke('delete-ai-key'),
     updateSettings: (newPrompt) =>
       updateCurrentPile({ ...currentPile, AIPrompt: newPrompt }),

--- a/src/renderer/pages/Pile/Chat/Chat.module.scss
+++ b/src/renderer/pages/Pile/Chat/Chat.module.scss
@@ -32,6 +32,11 @@
   &:active {
     background: var(--bg-tertiary);
   }
+
+  &.disabled {
+    pointer-events: none; // Prevent interaction
+    opacity: 0.5; // Make the whole container look disabled
+  }
 }
 
 button,

--- a/src/renderer/pages/Pile/Chat/index.jsx
+++ b/src/renderer/pages/Pile/Chat/index.jsx
@@ -28,6 +28,7 @@ import Blobs from './Blobs';
 import useChat from 'renderer/hooks/useChat';
 
 export default function Chat() {
+  const { validKey } = useAIContext();
   const { currentTheme, setTheme } = usePilesContext();
   const { getAIResponse, addMessage, resetMessages } = useChat();
   const [container, setContainer] = useState(null);
@@ -35,6 +36,16 @@ export default function Chat() {
   const [text, setText] = useState('');
   const [querying, setQuerying] = useState(false);
   const [history, setHistory] = useState([]);
+  const [aiApiKeyValid, setAiApiKeyValid] = useState(false);
+
+  // Check if the AI API key is valid
+  useEffect(() => {
+    const checkApiKeyValid = async () => {
+      const valid = await validKey();
+      setAiApiKeyValid(valid);
+    };
+    checkApiKeyValid();
+  }, [validKey]);
 
   const onChangeText = (e) => {
     setText(e.target.value);
@@ -92,7 +103,10 @@ export default function Chat() {
     <>
       <Dialog.Root>
         <Dialog.Trigger asChild>
-          <div className={styles.iconHolder}>
+          <div
+            className={`${styles.iconHolder} ${!aiApiKeyValid ? styles.disabled : ''}`}
+            onClick={!aiApiKeyValid ? (e) => e.preventDefault() : undefined} // Prevent click if no AI api key is set
+          >
             <ChatIcon className={styles.chatIcon} />
           </div>
         </Dialog.Trigger>

--- a/src/renderer/pages/Pile/Posts/Post/Post.module.scss
+++ b/src/renderer/pages/Pile/Posts/Post/Post.module.scss
@@ -248,6 +248,13 @@
       filter: contrast(0.85);
     }
 
+    &:disabled {
+      color: var(--secondary);
+      cursor: not-allowed; // Prevent pointer cursor
+      pointer-events: none; // Disable any interactions (e.g., clicks)
+      opacity: 0.5; // Reduce opacity to visually indicate it's disabled
+    }
+
     .icon {
       display: flex;
       justify-content: space-between;

--- a/src/renderer/pages/Pile/Posts/Post/index.jsx
+++ b/src/renderer/pages/Pile/Posts/Post/index.jsx
@@ -22,16 +22,28 @@ import {
 import { useTimelineContext } from 'renderer/context/TimelineContext';
 import Ball from './Ball';
 import { useHighlightsContext } from 'renderer/context/HighlightsContext';
+import { useAIContext } from 'renderer/context/AIContext';
 
 const Post = memo(({ postPath, searchTerm = null, repliesCount = 0 }) => {
   const { currentPile, getCurrentPilePath } = usePilesContext();
   const { highlights } = useHighlightsContext();
+  const { getKey } = useAIContext();
   // const { setClosestDate } = useTimelineContext();
   const { post, cycleColor, refreshPost, setHighlight } = usePost(postPath);
   const [hovering, setHover] = useState(false);
   const [replying, setReplying] = useState(false);
   const [isAIResplying, setIsAiReplying] = useState(false);
   const [editable, setEditable] = useState(false);
+  const [aiApiKey, setAiApiKey] = useState(null);
+
+  // Load AI API key from getKey()
+  useEffect(() => {
+    const fetchAiApiKey = async () => {
+      const key = await getKey();
+      setAiApiKey(key);
+    };
+    fetchAiApiKey();
+  }, [getKey]);
 
   const closeReply = () => {
     setReplying(false);
@@ -157,6 +169,7 @@ const Post = memo(({ postPath, searchTerm = null, repliesCount = 0 }) => {
                 <div className={styles.sep}>/</div>
                 <button
                   className={styles.openReply}
+                  disabled={aiApiKey === null}
                   onClick={() => {
                     setIsAiReplying(true);
                     toggleReplying();

--- a/src/renderer/pages/Pile/Posts/Post/index.jsx
+++ b/src/renderer/pages/Pile/Posts/Post/index.jsx
@@ -27,23 +27,23 @@ import { useAIContext } from 'renderer/context/AIContext';
 const Post = memo(({ postPath, searchTerm = null, repliesCount = 0 }) => {
   const { currentPile, getCurrentPilePath } = usePilesContext();
   const { highlights } = useHighlightsContext();
-  const { getKey } = useAIContext();
+  const { validKey } = useAIContext();
   // const { setClosestDate } = useTimelineContext();
   const { post, cycleColor, refreshPost, setHighlight } = usePost(postPath);
   const [hovering, setHover] = useState(false);
   const [replying, setReplying] = useState(false);
   const [isAIResplying, setIsAiReplying] = useState(false);
   const [editable, setEditable] = useState(false);
-  const [aiApiKey, setAiApiKey] = useState(null);
+  const [aiApiKeyValid, setAiApiKeyValid] = useState(false);
 
-  // Load AI API key from getKey()
+  // Check if the AI API key is valid
   useEffect(() => {
-    const fetchAiApiKey = async () => {
-      const key = await getKey();
-      setAiApiKey(key);
+    const checkApiKeyValid = async () => {
+      const valid = await validKey();
+      setAiApiKeyValid(valid);
     };
-    fetchAiApiKey();
-  }, [getKey]);
+    checkApiKeyValid();
+  }, [validKey]);
 
   const closeReply = () => {
     setReplying(false);
@@ -169,7 +169,7 @@ const Post = memo(({ postPath, searchTerm = null, repliesCount = 0 }) => {
                 <div className={styles.sep}>/</div>
                 <button
                   className={styles.openReply}
-                  disabled={aiApiKey === null}
+                  disabled={!aiApiKeyValid}
                   onClick={() => {
                     setIsAiReplying(true);
                     toggleReplying();


### PR DESCRIPTION
Hey again, @UdaraJay! 👋

This PR fixes [issue #85](https://github.com/UdaraJay/Pile/issues/85).

#### No API key set
<img width="867" alt="Screenshot 2024-11-26 at 2 44 56 PM" src="https://github.com/user-attachments/assets/ed16139a-5998-46f9-8bdf-783014ffabe1">

<img width="632" alt="Screenshot 2024-11-26 at 2 05 19 PM" src="https://github.com/user-attachments/assets/f086c952-bc11-45a0-ba89-a2a74ce1623c">

#### API key set
<img width="860" alt="Screenshot 2024-11-26 at 2 45 38 PM" src="https://github.com/user-attachments/assets/66a6b8bc-4b91-4d39-bb4d-31866c422c66">

<img width="634" alt="Screenshot 2024-11-26 at 2 06 29 PM" src="https://github.com/user-attachments/assets/54da9b13-a66b-43d5-a841-2a75f8a8a0fa">

---

In `AIContext.js`, the `checkApiKeyValidity()` function is designed for future use with Regex to validate input keys against OpenAPI or Ollama key formats.

---

@UdaraJay, would your app benefit if this button's icon was changed to a "spark" icon to indicate it's AI features? (✨)

<img width="100" alt="Screenshot 2024-11-26 at 2 07 44 PM" src="https://github.com/user-attachments/assets/01f17204-3b31-4b83-a395-a47c830568e4">

[The Unstoppable Rise of Spark ✨, as Ai’s Iconic Symbol](https://medium.com/design-bootcamp/the-unstoppable-rise-of-spark-as-ais-iconic-symbol-ca663162cccc)